### PR TITLE
chore: remove redundant name field from canary release job

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   canary-release:
-    name: Release
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -15,7 +14,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
chore: remove redundant name field from canary release job